### PR TITLE
Solve the problem where touch events work weirdly on mobile

### DIFF
--- a/js/contents.js
+++ b/js/contents.js
@@ -10,6 +10,9 @@
 
 function expandGroups(event) {
   var els = document.getElementsByClassName('title');
+  if (event === 'touchend') {
+    event.preventDefault();
+  }
   Array.prototype.forEach.call(els, function(el) {
     el.addEventListener(event, function() {
       el.parentElement.classList.toggle('expand');


### PR DESCRIPTION
Stop further propagation of events once 'touched' event had been received. Since `event.preventDefault()` prevents mouse event from being delivered, you need an if statement first.
Reference [event.preventDefault() on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault).
